### PR TITLE
Make mitmproxy script compatible with mitmproxy 6+.

### DIFF
--- a/mitmproxy_oracleforms.py
+++ b/mitmproxy_oracleforms.py
@@ -145,7 +145,7 @@ class OracleForms:
 
             ctx.log("RC4 initialized with key: %s" % (repr(self.key)))
             if ctx.options.corrupt_handshake:
-                flow.response.replace("Mate", "Matf")
+                flow.response.content = flow.response.content.replace(b"Mate", b"Matf")
             return
         if b"ifError:11/" in flow.response.content:
             with self.resp_lock:


### PR DESCRIPTION
The change on line 148 makes the mitmproxy script compatible with version 6 and upwards of mitmproxy.

Tested this morning with mitmproxy 10.